### PR TITLE
fix: remove deprecated function

### DIFF
--- a/lua/lspconf.lua
+++ b/lua/lspconf.lua
@@ -86,7 +86,7 @@ end
 
 -- Add additional capabilities supported by nvim-cmp
 local capabilities = vim.lsp.protocol.make_client_capabilities()
-capabilities = require('cmp_nvim_lsp').update_capabilities(capabilities)
+capabilities = require('cmp_nvim_lsp').default_capabilities(capabilities)
 
 local lspconfig = require('lspconfig')
 


### PR DESCRIPTION
cmp_nvim_lsp.update_capabilities is deprecated, use cmp_nvim_lsp.default_capabilities instead. See :h deprecated                                                                                                    This function will be removed in cmp-nvim-lsp version 1.0.0